### PR TITLE
Improve fmt::Debug for WalletIcon

### DIFF
--- a/crate/src/wallet.rs
+++ b/crate/src/wallet.rs
@@ -95,11 +95,23 @@ impl Reflection {
 }
 
 /// A data URI containing a base64-encoded SVG, WebP, PNG, or GIF image.
-#[derive(Debug, Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct WalletIcon(
     /// Format `data:image/${'svg+xml' | 'webp' | 'png' | 'gif'};base64,${string}`
     pub Cow<'static, str>,
 );
+
+impl core::fmt::Debug for WalletIcon {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let value = if let Some((first, _)) = self.0.split_once(",") {
+            first
+        } else {
+            &self.0
+        };
+
+        write!(f, "{value}",)
+    }
+}
 
 #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SemverVersion {


### PR DESCRIPTION
Custom Debug implementation now ensures that only the MIME type
and data encoding format is printed so that encoded data is not shown
since showing it is irrelevant.

However, if the split mechanism dosent work then the even the encoded
data is shown
