### PR TITLE
Channel propagation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ categories = ["cryptography::cryptocurrencies"]
 
 [workspace.dependencies]
 wallet-adapter = { path = "./crate" }
+async-channel = "2.3.1"
+log = "0.4.22"
 bs58 = { version = "0.5.1" }
 wasm-bindgen = "0.2.99"
 wasm-bindgen-futures = "0.4.7"

--- a/Error-Codes.md
+++ b/Error-Codes.md
@@ -1,0 +1,7 @@
+### List of error codes and their explanation
+
+- `WE01` - The `accounts` key was not found in the JavaScript object returned from invoking the event `change` dispathced from invoking `on` method from `[standard:events]` namespace.
+- `WE02` - The JavaScript object returned from invoking the event `change` dispathced from invoking `on` method from `[standard:events]` namespace is either undefined or null
+- `WE03` - The Uint8Array returned from the result of the JavaScript object returned from invoking the event `change` dispathced from invoking `on` method from `[standard:events]` namespace is not 32 bytes in length therefore it is automatically and invalid Ed25519 public key
+- `WE04` - The Uint8Array returned from the result of the JavaScript object returned from invoking the event `change` dispathced from invoking `on` method from `[standard:events]` namespace returned 32 bytes that are invalid for converting them to an Ed25519 public key
+- `WE05` - unable to convert the callback function for the `on` method from `[standard:events]` namespace to a JavaScript function

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -13,6 +13,7 @@ readme.workspace = true
 ed25519-dalek = { version = "2.1.1", default-features = false, features = [
     "signature",
 ] }
+async-channel.workspace = true
 web-sys.workspace = true
 js-sys.workspace = true
 wasm-bindgen.workspace = true
@@ -24,7 +25,11 @@ rand_chacha = "0.3.1"
 getrandom = { version = "0.2.15", features = ["js"] }
 bs58.workspace = true
 blake3 = { version = "1.5.1", default-features = false }
+log = { workspace = true, optional = true }
 
+[features]
+default = ["logging"]
+logging = ["dep:log"]
 
 [dev-dependencies]
 solana-sdk = "2.1.2"

--- a/crate/src/errors.rs
+++ b/crate/src/errors.rs
@@ -21,6 +21,11 @@ pub enum WalletError {
         /// The stack from the JavaScript error message
         stack: String,
     },
+    /// Occurs when casting a JavaScript type to a Rust type using [js_sys::JsCast] trait
+    /// and `foo.dyn_ref::<T>()` or `foo.dyn_into::<T>()` where `foo`
+    /// is a variable of type [wasm_bindgen::JsValue]
+    #[error("Occurs when casting a JavaScript type to a Rust type using `js_sys::JsCast` trait and `foo.dyn_ref::<T>()` or `foo.dyn_into::<T>()` where `foo` is a variable of type `wasm_bindgen::JsValue`")]
+    JsCast(String),
     /// Unable to parse an `Err(JsValue)` to get the `name`, `message` or `stack`. One, some or all of these values might be missing
     #[error("Unable to parse an `Err(JsValue)` to get the `name`, `message` or `stack`. One, some or all of these values might be missing")]
     UnableToParseJsError,

--- a/crate/src/errors.rs
+++ b/crate/src/errors.rs
@@ -190,6 +190,12 @@ pub enum WalletError {
     SendAndSignTransactionSignatureEmpty,
 }
 
+impl WalletError {
+    pub(crate) fn format_error(error_code: &str, error: &str) -> String {
+        String::from("WE") + error_code + "> " + error
+    }
+}
+
 impl From<JsValue> for WalletError {
     fn from(value: JsValue) -> Self {
         let reflect = |key: &str| -> Result<String, Self> {

--- a/crate/src/utils.rs
+++ b/crate/src/utils.rs
@@ -1,3 +1,5 @@
+use core::fmt;
+
 use ed25519_dalek::{Signature, Verifier, VerifyingKey};
 use js_sys::{Array, Function, Object, Reflect};
 use wasm_bindgen::{JsCast, JsValue};
@@ -13,6 +15,28 @@ pub type SignatureBytes = [u8; 64];
 /// The Version of the Wallet Standard currently implemented.
 /// This may be used by the app to determine compatibility and feature detect.
 pub const WALLET_STANDARD_VERSION: &str = "1.0.0";
+
+pub(crate) struct Logger;
+
+impl Logger {
+    pub fn value(value: impl fmt::Debug) {
+        Self::key_value("", value)
+    }
+
+    pub fn key_value(key: impl fmt::Debug, value: impl fmt::Debug) {
+        #[cfg(any(all(feature = "logging", debug_assertions)))]
+        log::info!("{key:?} {value:?}");
+    }
+
+    pub fn web_sys_value(key: &JsValue) {
+        Self::web_sys_key_value(key, &"".into());
+    }
+
+    pub fn web_sys_key_value(key: &JsValue, value: &JsValue) {
+        #[cfg(any(feature = "logging", debug_assertions))]
+        web_sys::console::log_2(key, value);
+    }
+}
 
 /// Helper utilities
 pub struct Utils;

--- a/crate/src/wallet_ser_der/standard_features/disconnect.rs
+++ b/crate/src/wallet_ser_der/standard_features/disconnect.rs
@@ -1,6 +1,6 @@
 use wasm_bindgen::JsValue;
 
-use crate::{SemverVersion, StandardFunction, WalletError, WalletResult};
+use crate::{Reflection, SemverVersion, StandardFunction, WalletError, WalletResult};
 
 /// `standard:disconnect` struct containing the `version` and `callback`
 /// in the field [StandardFunction]
@@ -9,9 +9,9 @@ pub struct Disconnect(StandardFunction);
 
 impl Disconnect {
     /// Parse the `standard:disconnect` callback from the [JsValue]
-    pub fn new(value: JsValue, version: SemverVersion) -> WalletResult<Self> {
+    pub(crate) fn new(reflection: &Reflection, version: SemverVersion) -> WalletResult<Self> {
         Ok(Self(StandardFunction::new(
-            value,
+            reflection,
             version,
             "disconnect",
             "standard",

--- a/crate/src/wallet_ser_der/standard_features/events.rs
+++ b/crate/src/wallet_ser_der/standard_features/events.rs
@@ -1,7 +1,9 @@
-use js_sys::Function;
-use wasm_bindgen::{prelude::Closure, JsCast, JsValue};
+use wasm_bindgen::{prelude::Closure, JsValue};
 
-use crate::{Reflection, SemverVersion, StandardFunction, WalletError, WalletResult};
+use crate::{
+    ConnectionInfoInner, Reflection, SemverVersion, StandardFunction, Utils, WalletError,
+    WalletEvent, WalletEventSender, WalletResult,
+};
 
 /// `standard:events` struct containing the `version` and `callback`
 /// within the [StandardFunction] field
@@ -10,22 +12,81 @@ pub struct StandardEvents(StandardFunction);
 
 impl StandardEvents {
     /// parse the callback for `standard:events` from the [JsValue]
-    pub fn new(value: JsValue, version: SemverVersion) -> WalletResult<Self> {
+    pub fn new(
+        value: JsValue,
+        version: SemverVersion,
+        sender: WalletEventSender,
+        connection_info: ConnectionInfoInner,
+    ) -> WalletResult<Self> {
         let get_standard_event_fn = Reflection::new(value)?.get_function("on")?;
 
-        let on_account_change = Closure::wrap(Box::new(move |value: JsValue| {
-            web_sys::console::log_2(&"CALLED ON CONNECTED FEATURE".into(), &value);
-        }) as Box<dyn Fn(_)>);
-        let on_account_change_fn = on_account_change.as_ref().dyn_ref::<Function>().unwrap();
+        let connection_exists = connection_info
+            .as_ref()
+            .borrow()
+            .connected_account_raw()
+            .is_some();
 
-        get_standard_event_fn
-            .call2(
-                &JsValue::null(),
-                &"change".into(),
-                &on_account_change_fn.into(),
-            )
-            .unwrap();
-        on_account_change.forget();
+        let sender_inner = sender.clone();
+
+        let on_account_change = Closure::wrap(Box::new(move |value: JsValue| {
+            let sender2 = sender_inner.clone();
+
+            let send_message = |wallet_event: WalletEvent| async move {
+                sender2
+                    .send(wallet_event)
+                    .await
+                    .expect("E01> Could not send message. Channel Closed");
+            };
+
+            let connection_info_inner = std::rc::Rc::clone(&connection_info);
+
+            let public_key_changed_raw = Reflection::new(value)
+                .expect(&WalletError::format_error(
+                    "02",
+                    "PublicKey is undefined or null",
+                ))
+                .reflect_inner_as_bytes("accounts", "01")
+                .expect(&WalletError::format_error(
+                    "01",
+                    "`accounts` key not found in object",
+                ));
+            let public_key_bytes =
+                Utils::to32byte_array(&public_key_changed_raw).expect(&WalletError::format_error(
+                    "03",
+                    "Invalid Bytes, expected 32 bytes as a requirement for Ed25519 PublicKey",
+                ));
+
+            Utils::public_key(public_key_bytes).expect(&WalletError::format_error(
+                "04",
+                "The bytes provided are invalid for conversion to an Ed25519 public key",
+            ));
+
+            wasm_bindgen_futures::spawn_local(async move {
+                if !public_key_changed_raw.is_empty() {
+                    if connection_exists {
+                        send_message.clone()(WalletEvent::AccountChanged).await;
+                    } else {
+                        send_message(WalletEvent::Connected).await;
+                    }
+                } else {
+                    connection_info_inner
+                        .borrow_mut()
+                        .disconnect()
+                        .await
+                        .expect("Received a disconnect event from the browser wallet but the `WalletAdapter::disconnect` did not execute successfully.");
+                    send_message(WalletEvent::Disconnected).await;
+                }
+            });
+        }) as Box<dyn FnMut(JsValue)>);
+
+        let on_account_change_fn =
+            Reflection::as_function_owned(on_account_change.into_js_value(), "05")?;
+
+        get_standard_event_fn.call2(
+            &JsValue::null(),
+            &"change".into(),
+            &on_account_change_fn.into(),
+        )?;
 
         Ok(Self(StandardFunction {
             version,

--- a/crate/src/wallet_ser_der/standard_features/events.rs
+++ b/crate/src/wallet_ser_der/standard_features/events.rs
@@ -1,7 +1,10 @@
+use std::{future::Future, pin::Pin};
+
+use async_channel::Receiver;
 use wasm_bindgen::{prelude::Closure, JsValue};
 
 use crate::{
-    ConnectionInfoInner, Reflection, SemverVersion, StandardFunction, Utils, WalletError,
+    ConnectionInfoInner, Reflection, SemverVersion, StandardFunction, WalletAccount, WalletError,
     WalletEvent, WalletEventSender, WalletResult,
 };
 
@@ -12,81 +15,8 @@ pub struct StandardEvents(StandardFunction);
 
 impl StandardEvents {
     /// parse the callback for `standard:events` from the [JsValue]
-    pub fn new(
-        value: JsValue,
-        version: SemverVersion,
-        sender: WalletEventSender,
-        connection_info: ConnectionInfoInner,
-    ) -> WalletResult<Self> {
-        let get_standard_event_fn = Reflection::new(value)?.get_function("on")?;
-
-        let connection_exists = connection_info
-            .as_ref()
-            .borrow()
-            .connected_account_raw()
-            .is_some();
-
-        let sender_inner = sender.clone();
-
-        let on_account_change = Closure::wrap(Box::new(move |value: JsValue| {
-            let sender2 = sender_inner.clone();
-
-            let send_message = |wallet_event: WalletEvent| async move {
-                sender2
-                    .send(wallet_event)
-                    .await
-                    .expect("E01> Could not send message. Channel Closed");
-            };
-
-            let connection_info_inner = std::rc::Rc::clone(&connection_info);
-
-            let public_key_changed_raw = Reflection::new(value)
-                .expect(&WalletError::format_error(
-                    "02",
-                    "PublicKey is undefined or null",
-                ))
-                .reflect_inner_as_bytes("accounts", "01")
-                .expect(&WalletError::format_error(
-                    "01",
-                    "`accounts` key not found in object",
-                ));
-            let public_key_bytes =
-                Utils::to32byte_array(&public_key_changed_raw).expect(&WalletError::format_error(
-                    "03",
-                    "Invalid Bytes, expected 32 bytes as a requirement for Ed25519 PublicKey",
-                ));
-
-            Utils::public_key(public_key_bytes).expect(&WalletError::format_error(
-                "04",
-                "The bytes provided are invalid for conversion to an Ed25519 public key",
-            ));
-
-            wasm_bindgen_futures::spawn_local(async move {
-                if !public_key_changed_raw.is_empty() {
-                    if connection_exists {
-                        send_message.clone()(WalletEvent::AccountChanged).await;
-                    } else {
-                        send_message(WalletEvent::Connected).await;
-                    }
-                } else {
-                    connection_info_inner
-                        .borrow_mut()
-                        .disconnect()
-                        .await
-                        .expect("Received a disconnect event from the browser wallet but the `WalletAdapter::disconnect` did not execute successfully.");
-                    send_message(WalletEvent::Disconnected).await;
-                }
-            });
-        }) as Box<dyn FnMut(JsValue)>);
-
-        let on_account_change_fn =
-            Reflection::as_function_owned(on_account_change.into_js_value(), "05")?;
-
-        get_standard_event_fn.call2(
-            &JsValue::null(),
-            &"change".into(),
-            &on_account_change_fn.into(),
-        )?;
+    pub(crate) fn new(reflection: &Reflection, version: SemverVersion) -> WalletResult<Self> {
+        let get_standard_event_fn = reflection.get_function("on")?;
 
         Ok(Self(StandardFunction {
             version,
@@ -94,16 +24,136 @@ impl StandardEvents {
         }))
     }
 
-    pub(crate) async fn call_standard_event(&self) -> WalletResult<()> {
-        let outcome = self.0.callback.call0(&JsValue::from_bool(false))?;
+    pub(crate) async fn call_on_event(
+        &self,
+        connection_info: ConnectionInfoInner,
+        wallet_name: String,
+        sender: WalletEventSender,
+        stop_signal: Receiver<()>,
+    ) -> WalletResult<()> {
+        let sender2 = sender.clone();
 
-        let outcome = js_sys::Promise::resolve(&outcome);
+        let on_account_change = Closure::wrap(Box::new(move |value: JsValue| {
+            let wallet_name = wallet_name.clone();
+            web_sys::console::log_3(
+                &"CALLED ON EV for ".into(),
+                &wallet_name.clone().into(),
+                &value,
+            );
 
-        if let Some(error) = wasm_bindgen_futures::JsFuture::from(outcome).await.err() {
-            let value: WalletError = error.into();
-            return Err(WalletError::StandardEventsError(value.to_string()));
-        }
+            let connection_info_inner = connection_info.clone();
+            let sender_inner = sender2.clone();
+
+            wasm_bindgen_futures::spawn_local(async move {
+                let reflect_accounts =
+                    send_wallet_event_error()(Reflection::new(value), sender_inner.clone())
+                        .await
+                        .unwrap(); // Never fails
+                let mut get_accounts = send_wallet_event_error()(
+                    reflect_accounts.reflect_js_array("accounts"),
+                    sender_inner.clone(),
+                )
+                .await
+                .unwrap()
+                .to_vec(); // Never fails
+
+                let processed_wallet_account = if !get_accounts.is_empty() {
+                    let first_account = send_wallet_event_error()(
+                        Reflection::new(get_accounts.remove(0)),
+                        sender_inner.clone(),
+                    )
+                    .await
+                    .unwrap(); // Never fails
+
+                    let account_processing = send_wallet_event_error()(
+                        WalletAccount::parse(first_account),
+                        sender_inner.clone(),
+                    )
+                    .await
+                    .unwrap(); //Never fails
+                    web_sys::console::error_2(
+                        &"PRE ACCOUNT PROCESSING".into(),
+                        &format!("{account_processing:?}").into(),
+                    );
+
+                    Some(account_processing)
+                } else {
+                    Option::None
+                };
+
+                connection_info_inner
+                    .borrow_mut()
+                    .emit_wallet_event(&wallet_name, processed_wallet_account, sender_inner.clone())
+                    .await
+            });
+        }) as Box<dyn Fn(_)>);
+
+        let on_account_change_fn =
+            Reflection::new(on_account_change.into_js_value())?.as_function_owned()?;
+
+        let on_event_fn = self.0.callback.clone();
+
+        wasm_bindgen_futures::spawn_local(async move {
+            while let Ok(_) = stop_signal.recv().await {
+                let invoke_outcome = on_event_fn
+                    .call2(
+                        &JsValue::null(),
+                        &"change".into(),
+                        &on_account_change_fn.clone().into(),
+                    )
+                    .map_err(|error| {
+                        let into_error: WalletError = error.into();
+
+                        into_error
+                    });
+
+                send_wallet_event_error()(invoke_outcome, sender.clone())
+                    .await
+                    .unwrap();
+            }
+        });
 
         Ok(())
+    }
+}
+
+pub(crate) async fn send_wallet_event(wallet_event: WalletEvent, sender: WalletEventSender) {
+    if let Err(error) = sender.clone().send(wallet_event).await {
+        web_sys::console::log_2(
+            &"BACKGROUND TASK ERROR: [standard:events]on() > ".into(),
+            &format!("{error:?}").into(),
+        );
+    }
+}
+
+pub(crate) fn send_wallet_event_error<T>(
+) -> impl Fn(WalletResult<T>, WalletEventSender) -> Pin<Box<dyn Future<Output = Result<T, ()>>>> + 'static
+where
+    T: core::fmt::Debug + 'static,
+{
+    move |outcome: WalletResult<T>, sender: WalletEventSender| {
+        Box::pin(async move {
+            match outcome {
+                Ok(value) => Ok(value),
+                Err(error) => {
+                    web_sys::console::log_2(
+                        &"BACKGROUND TASK ERROR: [standard:events]on() > ".into(),
+                        &format!("{error:?}").into(),
+                    );
+
+                    if let Err(channel_error) = sender
+                        .send(WalletEvent::BackgroundTaskError(error.clone()))
+                        .await
+                    {
+                        web_sys::console::log_2(
+                            &"Encountered error while sending a wallet event: ".into(),
+                            &format!("{channel_error:?}").into(),
+                        );
+                    }
+
+                    Err(())
+                }
+            }
+        })
     }
 }

--- a/crate/src/wallet_ser_der/standard_features/features.rs
+++ b/crate/src/wallet_ser_der/standard_features/features.rs
@@ -1,6 +1,6 @@
 use crate::{
-    Connect, ConnectionInfoInner, Disconnect, FeatureSupport, Reflection, SemverVersion, SignIn,
-    SignMessage, SignTransaction, StandardEvents, WalletError, WalletEventSender, WalletResult,
+    Connect, Disconnect, FeatureSupport, Reflection, SemverVersion, SignIn, SignMessage,
+    SignTransaction, StandardEvents, WalletError, WalletResult,
     SOLANA_SIGN_AND_SEND_TRANSACTION_IDENTIFIER, SOLANA_SIGN_IN_IDENTIFIER,
     SOLANA_SIGN_MESSAGE_IDENTIFIER, SOLANA_SIGN_TRANSACTION_IDENTIFIER,
     STANDARD_CONNECT_IDENTIFIER, STANDARD_DISCONNECT_IDENTIFIER, STANDARD_EVENTS_IDENTIFIER,
@@ -17,7 +17,7 @@ pub struct Features {
     /// standard:disconnect
     pub(crate) disconnect: Disconnect,
     /// standard:events
-    pub(crate) events: Option<StandardEvents>,
+    pub(crate) events: StandardEvents,
     /// solana:signAndSendTransaction
     pub(crate) sign_and_send_tx: SignTransaction,
     /// solana:signTransaction
@@ -32,11 +32,7 @@ pub struct Features {
 
 impl Features {
     /// Parse all the features from a wallet described as a [wasm_bindgen::JsValue]
-    pub(crate) fn parse(
-        reflection: &Reflection,
-        sender: WalletEventSender,
-        connection_info: ConnectionInfoInner,
-    ) -> WalletResult<(Self, FeatureSupport)> {
+    pub(crate) fn parse(reflection: &Reflection) -> WalletResult<(Self, FeatureSupport)> {
         let features_keys = reflection.object_to_vec_string("features")?;
         let features_object = Reflection::new_from_str(reflection.get_inner(), "features")?;
 
@@ -45,38 +41,34 @@ impl Features {
 
         features_keys.into_iter().try_for_each(|feature| {
             let inner_object = features_object.reflect_inner(&feature)?;
+            let inner_object = Reflection::new(inner_object)?;
 
             if feature.starts_with("standard:") || feature.starts_with("solana:") {
                 let version = SemverVersion::from_jsvalue(&inner_object)?;
 
                 if feature == STANDARD_CONNECT_IDENTIFIER {
-                    features.connect = Connect::new(inner_object, version)?;
+                    features.connect = Connect::new(&inner_object, version)?;
                     supported_features.connect = true;
                 } else if feature == STANDARD_DISCONNECT_IDENTIFIER {
-                    features.disconnect = Disconnect::new(inner_object, version)?;
+                    features.disconnect = Disconnect::new(&inner_object, version)?;
                     supported_features.disconnect = true;
                 } else if feature == STANDARD_EVENTS_IDENTIFIER {
-                    features.events.replace(StandardEvents::new(
-                        inner_object,
-                        version,
-                        sender.clone(),
-                        connection_info.clone(),
-                    )?);
+                    features.events = StandardEvents::new(&inner_object, version)?;
                     supported_features.events = true;
                 } else if feature == SOLANA_SIGN_AND_SEND_TRANSACTION_IDENTIFIER {
                     features.sign_and_send_tx =
-                        SignTransaction::new_sign_and_send_tx(inner_object, version)?;
+                        SignTransaction::new_sign_and_send_tx(&inner_object, version)?;
                     supported_features.sign_and_send_tx = true;
                 } else if feature == SOLANA_SIGN_TRANSACTION_IDENTIFIER {
-                    features.sign_tx = SignTransaction::new_sign_tx(inner_object, version)?;
+                    features.sign_tx = SignTransaction::new_sign_tx(&inner_object, version)?;
                     supported_features.sign_tx = true;
                 } else if feature == SOLANA_SIGN_MESSAGE_IDENTIFIER {
-                    features.sign_message = SignMessage::new(inner_object, version)?;
+                    features.sign_message = SignMessage::new(&inner_object, version)?;
                     supported_features.sign_message = true;
                 } else if feature == SOLANA_SIGN_IN_IDENTIFIER {
                     features
                         .sign_in
-                        .replace(SignIn::new(inner_object, version)?);
+                        .replace(SignIn::new(&inner_object, version)?);
                     supported_features.sign_in = true;
                 } else {
                     return Err(WalletError::UnsupportedWalletFeature(feature));

--- a/crate/src/wallet_ser_der/version.rs
+++ b/crate/src/wallet_ser_der/version.rs
@@ -1,9 +1,6 @@
 use std::borrow::Cow;
 
-use wasm_bindgen::JsValue;
-use web_sys::js_sys::Reflect;
-
-use crate::{WalletError, WalletResult};
+use crate::{Reflection, WalletError, WalletResult};
 
 /// Semver Versioning struct
 #[derive(Clone, Default, PartialEq, Eq, PartialOrd, Ord, Hash)]
@@ -30,13 +27,12 @@ impl SemverVersion {
     }
 
     /// Parse the version from a [JsValue]
-    pub fn from_jsvalue(value: &JsValue) -> WalletResult<Self> {
-        let reflect_value =
-            Reflect::get(value, &"version".into()).or(Err(WalletError::VersionNotFound))?;
-
-        let version = reflect_value
+    pub(crate) fn from_jsvalue(reflection: &Reflection) -> WalletResult<Self> {
+        let version = reflection
+            .reflect_inner("version")
+            .or(Err(WalletError::VersionNotFound))?
             .as_string()
-            .ok_or(WalletError::ExpectedString(
+            .ok_or(WalletError::InternalError(
                 "Expected `version` JsValue to be a String".to_string(),
             ))?;
 

--- a/crate/src/wallet_ser_der/wallet.rs
+++ b/crate/src/wallet_ser_der/wallet.rs
@@ -3,8 +3,8 @@ use wasm_bindgen::{JsCast, JsValue};
 use web_sys::js_sys::Reflect;
 
 use crate::{
-    Cluster, Features, Reflection, SemverVersion, WalletAccount, WalletError, WalletIcon,
-    WalletResult,
+    Cluster, ConnectionInfoInner, Features, Reflection, SemverVersion, WalletAccount, WalletError,
+    WalletEventSender, WalletIcon, WalletResult,
 };
 
 use super::{
@@ -102,7 +102,11 @@ impl Wallet {
     }
 
     /// Parse the Wallet details from a [JsValue]
-    pub fn from_jsvalue(value: JsValue) -> WalletResult<Self> {
+    pub fn from_jsvalue(
+        value: JsValue,
+        sender: WalletEventSender,
+        connection_info: ConnectionInfoInner,
+    ) -> WalletResult<Self> {
         let reflection = Reflection::new(value)?;
 
         let mut supported_chains = ChainSupport::default();
@@ -132,7 +136,7 @@ impl Wallet {
         let version = SemverVersion::parse(&reflection.string("version")?)?;
         let icon = WalletIcon::from_jsvalue(&reflection)?;
         let accounts = Self::get_accounts(&reflection, "accounts")?;
-        let (features, supported_features) = Features::parse(&reflection)?;
+        let (features, supported_features) = Features::parse(&reflection, sender, connection_info)?;
 
         Ok(Wallet {
             name,

--- a/crate/src/wallet_ser_der/wallet_icon.rs
+++ b/crate/src/wallet_ser_der/wallet_icon.rs
@@ -14,13 +14,12 @@ impl WalletIcon {
     pub(crate) fn from_jsvalue(reflection: &Reflection) -> WalletResult<Option<WalletIcon>> {
         let icon = match reflection.string("icon") {
             Ok(icon) => Option::Some(WalletIcon(Cow::Owned(icon))),
-            Err(error) => {
-                if error == WalletError::JsValueNotString {
-                    Option::None
-                } else {
+            Err(error) => match error {
+                WalletError::InternalError(_) => Option::None,
+                _ => {
                     return Err(error);
                 }
-            }
+            },
         };
 
         Ok(icon)


### PR DESCRIPTION
- Propagate events from the `wallet[standard:events].on` method by parsing them as `WalletEvents`

- Improve error handling