### PR TITLE
Fixes for improving dev experience in library

### DIFF
--- a/crate/src/events.rs
+++ b/crate/src/events.rs
@@ -84,7 +84,8 @@ impl<'a> InitEvents<'a> {
         Ok(())
     }
 
-    pub(crate) fn register_object(storage: StorageType) -> Object {
+    /// Sets the object to be passed to the register function
+    pub fn register_object(storage: StorageType) -> Object {
         // The `register` function that logs and returns a closure like in your JS code
         let register =
             Closure::wrap(


### PR DESCRIPTION
- `WalletAdapter::init_with_channel_capacity` method creates a channel with a custom capacity

- `WalletAdapter::init_custom` method allows a developer to pass in a `Window` and `Document` if the two were already initialized elsewhere

- Expose `InitEvents::register_object` to external libraries

- Expose `Reflection` and all of its methods to externa libraries