### PR TITLE
Add a simple parse for anchor IDL

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crate"]
+members = ["crate", "partial-idl-parser"]
 
 resolver = "2"
 

--- a/partial-idl-parser/Cargo.toml
+++ b/partial-idl-parser/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "partial-idl-parser"
+authors.workspace = true
+version.workspace = true
+license.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+description = "A simple parser for anchor IDL without importing anchor types or causing build panics for WASM targets."
+homepage.workspace = true
+repository.workspace = true
+readme.workspace = true
+keywords.workspace = true
+categories.workspace = true
+publish = false
+
+[dependencies]
+serde = { version = "1.0.218", features = ["derive"] }
+serde_json = "1.0.139"

--- a/partial-idl-parser/README.md
+++ b/partial-idl-parser/README.md
@@ -1,0 +1,60 @@
+## Simple anchor IDL Parser
+A simple parser for partial part of anchor IDL without importing anchor types or causing build panics for WASM targets.
+
+It only parses the `address` of the program and the `instructions` containing the instruction `name` and the `discriminant` which are useful for the scope of the `wallet-adapter` templates.
+
+
+### Macro for creating a path to the IDL
+The frontend is in the same workspace as the target directory which contains the anchor IDL directory.
+
+The directory is in path `../../target/idl/`.
+
+Pass the name of the program from `/programs` so that the file is located successfully.
+
+Get the `AnchorIdlPartialData` data structure containing the IDL of an anchor example called `temp`
+
+```rust,ignore
+use partial_idl_parser::*;
+
+const IDL: &str = idl_path!("temp");
+```
+
+If the directory is different you can use `idl_custom_path` macro:
+```rust,ignore
+use partial_idl_parser::*;
+
+const IDL: &str = idl_custom_path!("../../target/custom_idl_dir", "temp");
+```
+
+### The `AnchorIdlPartialData`
+Parsed IDL is stored within a `AnchorIdlPartialData` struct.
+
+```rust,ignore
+fn foo() -> Result<(), serde_json::Error> {
+    use partial_idl_parser::*;
+
+    // Get the JSON IDL data
+    const IDL_RAW_DATA: &str = idl_path!("temp");
+
+    // Parse the JSON IDL
+    let parsed_idl = AnchorIdlPartialData::parse(IDL_RAW_DATA)?;
+
+    // Get program ID
+    parsed_idl.program_id();
+
+
+    // Get An Instruction by it's identifier assuming the instruction is
+    // labeled by the name `initialize`
+    parsed_idl.get_instruction("initialize");
+
+
+    // Get the instruction discriminant assuming the instruction is
+    // labeled by the name `initialize`
+    parsed_idl.get_discriminant("initialize");
+
+    Ok(())
+}
+```
+
+### LICENSE
+MIT OR APACHE-2.0

--- a/partial-idl-parser/src/lib.rs
+++ b/partial-idl-parser/src/lib.rs
@@ -1,0 +1,8 @@
+#![deny(unsafe_code)]
+#![deny(missing_docs)]
+#![doc = include_str!(concat!(std::env!("CARGO_MANIFEST_DIR"), "/README.md"))]
+
+mod path_macro;
+
+mod parser;
+pub use parser::*;

--- a/partial-idl-parser/src/parser.rs
+++ b/partial-idl-parser/src/parser.rs
@@ -1,0 +1,120 @@
+use serde::Deserialize;
+
+/// The discriminant length of anchor instruction
+pub type AnchorInstructionDiscriminatLen = [u8; 8];
+
+/// Holds the address and instructions parsed from JSON IDL.
+///
+/// 1. It contains the address of the program (Public Key) defined as a String
+///
+/// 2. The instructions of the program
+#[derive(Debug, Deserialize, PartialEq, PartialOrd)]
+pub struct AnchorIdlPartialData {
+    address: String,
+    instructions: Vec<AnchorInstruction>,
+}
+
+impl AnchorIdlPartialData {
+    /// Parse JSON IDL
+    pub fn parse(idl_json_data: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str::<Self>(idl_json_data)
+    }
+
+    /// Get the program ID
+    pub fn program_id(&self) -> &str {
+        self.address.as_str()
+    }
+
+    /// Get an instruction by the name defined in the JSON IDL
+    pub fn get_instruction(&self, name: &str) -> Option<&AnchorInstruction> {
+        self.instructions
+            .iter()
+            .find(|instruction| instruction.name.as_bytes() == name.as_bytes())
+    }
+
+    /// Get the discriminant of an instruction given the instruction name
+    pub fn get_discriminant(&self, name: &str) -> Option<AnchorInstructionDiscriminatLen> {
+        self.get_instruction(name).map(|ix| ix.discriminator)
+    }
+
+    /// Get all Instructions
+    pub fn get_instructions(&self) -> &[AnchorInstruction] {
+        self.instructions.as_slice()
+    }
+
+    /// Get all the names for all instructions
+    pub fn get_instruction_names(&self) -> Vec<&str> {
+        self.instructions
+            .iter()
+            .map(|instruction| instruction.name.as_str())
+            .collect::<Vec<&str>>()
+    }
+}
+
+/// An IDL defined instruction
+#[derive(Debug, Deserialize, PartialEq, PartialOrd)]
+pub struct AnchorInstruction {
+    /// Name of the Instruction
+    pub name: String,
+    /// The discriminant of the instruction
+    pub discriminator: [u8; 8],
+}
+
+#[cfg(test)]
+mod sanity_checks {
+    use super::AnchorIdlPartialData;
+
+    #[test]
+    fn correctness() {
+        let idl = "
+            {
+                \"address\": \"3bF44ZTKPSc4qZV97mpRA85NkQaM9D9Z6i3uYjKbs8E6\",
+                \"metadata\": {
+                    \"name\": \"temp\",
+                    \"version\": \"0.1.0\",
+                    \"spec\": \"0.1.0\",
+                    \"description\": \"Created with Anchor\"
+                },
+                \"instructions\": [
+                    {
+                    \"name\": \"initialize\",
+                    \"discriminator\": [
+                        175,
+                        175,
+                        109,
+                        31,
+                        13,
+                        152,
+                        155,
+                        237
+                    ],
+                    \"accounts\": [],
+                    \"args\": []
+                    }
+                ]
+            }
+        ";
+
+        let parse = AnchorIdlPartialData::parse(idl);
+        parse.as_ref().unwrap();
+
+        assert!(parse.is_ok());
+        assert_eq!(
+            parse.as_ref().unwrap().address,
+            "3bF44ZTKPSc4qZV97mpRA85NkQaM9D9Z6i3uYjKbs8E6"
+        );
+
+        assert_eq!(
+            parse
+                .as_ref()
+                .unwrap()
+                .get_instruction("initialize")
+                .map(|found| found.name.as_str()),
+            Some("initialize")
+        );
+        assert_eq!(
+            parse.as_ref().unwrap().get_discriminant("initialize"),
+            Some([175, 175, 109, 31, 13, 152, 155, 237])
+        );
+    }
+}

--- a/partial-idl-parser/src/path_macro.rs
+++ b/partial-idl-parser/src/path_macro.rs
@@ -1,0 +1,15 @@
+/// Get the IDL from the default directory `../../target/idl/` given a program name
+#[macro_export]
+macro_rules! idl_path {
+    ($program_name:expr) => {
+        include_str!(concat!("../../target/idl/", $program_name, ".json"))
+    };
+}
+
+/// Get the IDL from the custom directory given a program name.
+#[macro_export]
+macro_rules! idl_custom_path {
+    ($relative_dir_path:expr, $program_name:expr) => {
+        include_str!(concat!($relative_dir_path, $program_name, ".json"))
+    };
+}


### PR DESCRIPTION
importing Anchor types to the frontend causes compile time panics whenever targeting WASM. This library parses the anchor IDL instead using WASM friendly serde_json and serde crates