### PR TITLE
Fix clippy warning for newer versions of clippy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crate", "partial-idl-parser"]
 resolver = "2"
 
 [workspace.package]
-version = "1.1.2"
+version = "1.1.3"
 authors = ["448-OG <superuser@448.africa>"]
 description = "Solana Wallet Adapter for Rust clients written in pure Rust"
 homepage = "https://github.com/JamiiDao"
@@ -16,7 +16,7 @@ edition = "2021"
 rust-version = "1.84"
 
 [workspace.dependencies]
-async-channel = "2.3.1"
+async-channel = "2.5.0"
 log = "0.4.27"
 wasm-bindgen-futures = "0.4.50"
 

--- a/crate/src/events.rs
+++ b/crate/src/events.rs
@@ -162,6 +162,6 @@ impl core::fmt::Display for WalletEvent {
             Self::BackgroundTaskError(error) => &format!("Task error: {error:?}"),
             Self::Skip => "Skipped",
         };
-        write!(f, "{}", as_str)
+        write!(f, "{as_str}")
     }
 }


### PR DESCRIPTION
Clippy now requires variables to be used directly in the `format!` string Chore to upgrade async-channel crate