### PR TITLE
Add missing methods for supported features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crate", "partial-idl-parser", "wallet-adapter-common"]
 resolver = "2"
 
 [workspace.package]
-version = "1.2.0"
+version = "1.2.1"
 authors = ["448-OG <superuser@448.africa>"]
 description = "Solana Wallet Adapter for Rust clients written in pure Rust"
 homepage = "https://github.com/JamiiDao"

--- a/crate/src/wallet_ser_der/wallet_account.rs
+++ b/crate/src/wallet_ser_der/wallet_account.rs
@@ -171,6 +171,61 @@ impl WalletAccount {
             js_value: reflection.take(),
         })
     }
+
+    /// Checks if MainNet is supported
+    pub fn mainnet(&self) -> bool {
+        self.account.supported_chains.mainnet
+    }
+
+    /// Checks if DevNet is supported
+    pub fn devnet(&self) -> bool {
+        self.account.supported_chains.devnet
+    }
+
+    /// Checks if TestNet is supported
+    pub fn testnet(&self) -> bool {
+        self.account.supported_chains.testnet
+    }
+
+    /// Checks if LocalNet is supported
+    pub fn localnet(&self) -> bool {
+        self.account.supported_chains.localnet
+    }
+
+    /// Checks if `standard:connect` is supported
+    pub fn standard_connect(&self) -> bool {
+        self.account.supported_features.connect
+    }
+
+    /// Checks if `standard:disconnect` is supported
+    pub fn standard_disconnect(&self) -> bool {
+        self.account.supported_features.disconnect
+    }
+
+    /// Checks if `standard:events` is supported
+    pub fn standard_events(&self) -> bool {
+        self.account.supported_features.events
+    }
+
+    /// Checks if `solana:signIn` is supported
+    pub fn solana_signin(&self) -> bool {
+        self.account.supported_features.sign_in
+    }
+
+    /// Checks if `solana:signMessage` is supported
+    pub fn solana_sign_message(&self) -> bool {
+        self.account.supported_features.sign_message
+    }
+
+    /// Checks if `solana:signAndSendTransaction` is supported
+    pub fn solana_sign_and_send_transaction(&self) -> bool {
+        self.account.supported_features.sign_and_send_tx
+    }
+
+    /// Checks if `solana:signTransaction` is supported
+    pub fn solana_sign_transaction(&self) -> bool {
+        self.account.supported_features.sign_tx
+    }
 }
 
 impl core::fmt::Debug for WalletAccount {


### PR DESCRIPTION
This fixes a bug where `WalletAccount` is missing methods to detect features supported by the account