### PR TITLE
Allow undefined walletAccount features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,9 @@
 [workspace]
-members = [ "base","crate", "partial-idl-parser", "wallet-adapter-common"]
+members = ["base", "crate", "partial-idl-parser", "wallet-adapter-common"]
 resolver = "2"
 
 [workspace.package]
-version = "1.2.1"
+version = "1.2.2"
 authors = ["448-OG <superuser@448.africa>"]
 description = "Solana Wallet Adapter for Rust clients written in pure Rust"
 homepage = "https://github.com/JamiiDao"

--- a/crate/src/utils.rs
+++ b/crate/src/utils.rs
@@ -129,6 +129,14 @@ impl Reflection {
     }
 
     /// Reflect the `key` from the value of [Self](Reflection) and return the
+    /// reflected value as a [String]
+    pub fn string_optional(&self, key: &str) -> WalletResult<Option<String>> {
+        let name = Reflect::get(&self.0, &key.into())?;
+
+        Ok(name.as_string())
+    }
+
+    /// Reflect the `key` from the value of [Self](Reflection) and return the
     /// reflected value as a [Vec of Vec of bytes](Vec<Vec<u8>>)
     pub fn get_bytes_from_vec(&self, key: &str) -> WalletResult<Vec<Vec<u8>>> {
         let js_array = self.get_array()?;
@@ -197,13 +205,13 @@ impl Reflection {
 
     /// Reflect the `key` from the value of [Self](Reflection) and return the
     /// reflected value as a [Vec of String](Vec<String>)
-    pub fn vec_string(&self, key: &str) -> WalletResult<Vec<String>> {
+    pub fn vec_string_accept_undefined(&self, key: &str) -> WalletResult<Vec<String>> {
         let to_js_array = self.reflect_js_array(key)?;
 
-        to_js_array
+        Ok(to_js_array
             .iter()
-            .map(|value| Self::get_string(&value))
-            .collect::<WalletResult<Vec<String>>>()
+            .filter_map(|value| Self::get_string(&value).ok())
+            .collect::<Vec<String>>())
     }
 
     /// Reflect the `key` from the value of [Self](Reflection) and return the

--- a/crate/src/wallet_ser_der/wallet_account.rs
+++ b/crate/src/wallet_ser_der/wallet_account.rs
@@ -98,8 +98,8 @@ impl WalletAccount {
     pub(crate) fn parse(reflection: Reflection) -> WalletResult<Self> {
         let address = reflection.string("address")?;
         let public_key = reflection.byte32array("publicKey")?;
-        let chains = reflection.vec_string("chains")?;
-        let features = reflection.vec_string("features")?;
+        let chains = reflection.vec_string_accept_undefined("chains")?;
+        let features = reflection.vec_string_accept_undefined("features")?;
 
         let mut supported_chains = ChainSupport::default();
 

--- a/crate/src/wallet_ser_der/wallet_icon.rs
+++ b/crate/src/wallet_ser_der/wallet_icon.rs
@@ -6,8 +6,8 @@ pub(crate) struct WalletIcon;
 impl WalletIcon {
     /// Parse the wallet from a [web_sys::wasm_bindgen::JsValue]
     pub(crate) fn from_jsvalue(reflection: &Reflection) -> WalletResult<Option<String>> {
-        let icon = match reflection.string("icon") {
-            Ok(icon) => Option::Some(icon),
+        let icon = match reflection.string_optional("icon") {
+            Ok(icon) => icon,
             Err(error) => match error {
                 WalletError::InternalError(_) => Option::None,
                 _ => {


### PR DESCRIPTION
The wallet adapter panics if the icon and label for a walletAccount are undefined. This commit allows undefined as an acceptable value