### PR TITLE
Fix SignInInput borrowes strs requiring lifetimes

### DIFF
--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "wallet-standard-base"
-version = "0.1.4"
+version = "0.1.5"
 authors.workspace = true
 description = "The base features required by wallet-standard"
 homepage.workspace = true


### PR DESCRIPTION
Lifetimes required by the SignInInput methods for borrowed strings are creating a poor developer experience. This commit removes those lifetimes and instead uses Cow::Owned to take ownership of the values