### PR TITLE
Fix incompatible rand 0.10 and solana-sdk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["base", "crate", "partial-idl-parser", "wallet-adapter-common"]
 resolver = "2"
 
 [workspace.package]
-version = "1.4.1"
+version = "1.4.2"
 authors = ["448-OG <superuser@448.africa>"]
 description = "Solana Wallet Adapter for Rust clients written in pure Rust"
 homepage = "https://github.com/JamiiDao"
@@ -16,10 +16,6 @@ edition = "2021"
 rust-version = "1.84"
 
 [workspace.dependencies]
-wallet-adapter = { path = "./crate" }
-wallet-adapter-common = { path = "./wallet-adapter-common", version = "1.4.1" }
-wallet-standard-base = { path = "./base", version = "0.2.0" }
-
 base64ct = { version = "1.8.0", features = ["alloc"] }
 blake3 = { version = "1.8", default-features = false }
 ed25519-dalek = { version = "2.2.0", default-features = false, features = [
@@ -32,12 +28,15 @@ log = "0.4"
 wasm-bindgen-futures = "0.4"
 bs58 = "0.5.1"
 humantime = { version = "2.2.0", default-features = false }
-rand_chacha = { version = "0.10.0", default-features = false }
-rand_core = "0.10"
+rand_chacha = { version = "0.9", default-features = false, features = [
+    "std",
+    "os_rng",
+] }
+rand_core = "0.9"
+getrandom = { version = "0.3.1", features = ["wasm_js", "std"] }
 thiserror = { version = "2.0", default-features = false }
 async-lock = "3.4"
 zeroize = { version = "1.8.1", default-features = false }
-getrandom = { version = "0.4.1", features = ["wasm_js", "sys_rng"] }
 
 [workspace.dependencies.web-sys]
 version = "0.3"

--- a/base/Cargo.toml
+++ b/base/Cargo.toml
@@ -25,9 +25,9 @@ base64ct = { workspace = true, features = ["alloc"] }
 thiserror = { workspace = true, default-features = false }
 rand_chacha = { workspace = true, optional = true, default-features = false }
 rand_core = { workspace = true, optional = true }
+getrandom = { workspace = true, features = ["wasm_js", "std"] }
 blake3 = { workspace = true, default-features = false, optional = true }
 humantime = { workspace = true, default-features = false, optional = true }
-getrandom = { workspace = true, features = ["wasm_js", "sys_rng"] }
 
 [target.'cfg(not(target_arch = "aarch64"))'.dependencies]
 zeroize = { workspace = true, default-features = false, optional = true }

--- a/base/src/random.rs
+++ b/base/src/random.rs
@@ -10,12 +10,10 @@ impl<const N: usize> RandomBytes<N> {
     }
 
     pub fn generate_with_buffer(buffer: &mut [u8; N]) {
-        use getrandom::SysRng;
-
         use rand_chacha::ChaCha12Rng;
-        use rand_core::{Rng, SeedableRng};
+        use rand_core::{RngCore, SeedableRng};
 
-        let mut rng = ChaCha12Rng::try_from_rng(&mut SysRng).unwrap();
+        let mut rng = ChaCha12Rng::from_os_rng();
 
         rng.fill_bytes(buffer);
     }

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -24,7 +24,7 @@ rand_chacha.workspace = true
 bs58.workspace = true
 blake3.workspace = true
 async-lock.workspace = true
-wallet-adapter-common.workspace = true
+wallet-adapter-common = { path = "../wallet-adapter-common" }
 ed25519-dalek.workspace = true
 
 [dev-dependencies]

--- a/templates/dioxus-adapter/Cargo.toml
+++ b/templates/dioxus-adapter/Cargo.toml
@@ -11,16 +11,20 @@ publish = false
 [dependencies]
 dioxus = { version = "0.7.1", features = ["router"] }
 
-wallet-adapter = "1.2.2"
-solana-sdk = "2.1.2"
-bincode = "1.3.3"
+wallet-adapter = "1.4.2"
+bincode = "=1.3.3"
 jzon = "0.12.5"
 serde_json = "1.0.133"
 serde = { version = "1.0.215", features = ["derive"] }
 gloo-timers = "0.3.0"
-solana-transaction-error = { version = "2.1.13", features = ["serde"] }
 qrcodegen = "1.8.0"
 percent-encoding = "2.3.1"
+solana-transaction-error = { version = "3.0.0", default-features = false }
+solana-transaction = { version = "4.0.0", features = ["serde"] }
+solana-instruction = { version = "3.1.0", features = ["borsh"] }
+solana-pubkey = { version = "4.1.0", features = ["borsh"] }
+solana-hash = "4.2.0"
+solana-system-interface = { version = "3.0.0", features = ["bincode"] }
 
 
 [features]

--- a/templates/dioxus-adapter/src/fetch_parser.rs
+++ b/templates/dioxus-adapter/src/fetch_parser.rs
@@ -2,17 +2,17 @@ use std::str::FromStr;
 
 use dioxus::prelude::*;
 use serde::Deserialize;
-use solana_sdk::{
-    native_token::LAMPORTS_PER_SOL, pubkey::Pubkey, system_instruction::transfer,
-    transaction::Transaction,
-};
+use solana_pubkey::Pubkey;
+use solana_transaction::Transaction;
 use solana_transaction_error::TransactionError;
 use wallet_adapter::{
     web_sys::{js_sys::Date, wasm_bindgen::JsValue},
     SendOptions, WalletError, WalletResult,
 };
 
-use crate::{views::AccountState, FetchReq, ACCOUNT_STATE, CLUSTER_STORAGE, WALLET_ADAPTER};
+use crate::{
+    views::AccountState, FetchReq, ACCOUNT_STATE, CLUSTER_STORAGE, LAMPORTS_PER_SOL, WALLET_ADAPTER,
+};
 
 pub fn format_timestamp(unix_timestamp: i64) -> String {
     let timestamp_ms = unix_timestamp as f64 * 1000.0; //Convert seconds to millisconds
@@ -25,7 +25,7 @@ pub fn format_timestamp(unix_timestamp: i64) -> String {
         .unwrap_or("Invalid Timestamp".to_string())
 }
 
-async fn get_blockhash() -> WalletResult<solana_sdk::hash::Hash> {
+async fn get_blockhash() -> WalletResult<solana_hash::Hash> {
     let options = jzon::object! {
         "id":1,
         "jsonrpc":"2.0",
@@ -51,7 +51,7 @@ async fn get_blockhash() -> WalletResult<solana_sdk::hash::Hash> {
     )
     .unwrap();
 
-    solana_sdk::hash::Hash::from_str(deser.result.value.blockhash)
+    solana_hash::Hash::from_str(deser.result.value.blockhash)
         .map_err(|error| WalletError::Op(error.to_string()))
 }
 
@@ -99,7 +99,8 @@ pub async fn send_sol_req(
         "Invalid Recipient Address".to_string(),
     )))?;
 
-    let send_sol_instruction = transfer(&pubkey, &recipient, lamports);
+    let send_sol_instruction =
+        solana_system_interface::instruction::transfer(&pubkey, &recipient, lamports);
     let mut tx = Transaction::new_with_payer(&[send_sol_instruction], Some(&pubkey));
     let blockhash = get_blockhash().await?;
 

--- a/templates/dioxus-adapter/src/utils.rs
+++ b/templates/dioxus-adapter/src/utils.rs
@@ -4,6 +4,8 @@ use wallet_adapter::{wasm_bindgen_futures::JsFuture, Cluster, WalletResult};
 
 use crate::{DevnetSvg, LocalnetSvg, MainnetSvg, TestnetSvg, CLUSTER_STORAGE, WINDOW};
 
+pub const LAMPORTS_PER_SOL: u64 = 1_000_000_000;
+
 pub fn trunk_cluster_name(name: &str) -> String {
     if name.len() > 10 {
         name.chars().take(10).collect::<String>() + "..."

--- a/templates/dioxus-adapter/src/views/airdrop.rs
+++ b/templates/dioxus-adapter/src/views/airdrop.rs
@@ -1,9 +1,8 @@
 use dioxus::prelude::*;
-use solana_sdk::native_token::LAMPORTS_PER_SOL;
 
 use crate::{
     fetch_parser::request_airdrop, AirdropSvg, Loader, NotificationInfo, ACTIVE_CONNECTION,
-    GLOBAL_MESSAGE,
+    GLOBAL_MESSAGE, LAMPORTS_PER_SOL,
 };
 
 #[component]

--- a/templates/dioxus-adapter/src/views/extras_views/sign_tx.rs
+++ b/templates/dioxus-adapter/src/views/extras_views/sign_tx.rs
@@ -1,5 +1,6 @@
 use dioxus::prelude::*;
-use solana_sdk::{pubkey::Pubkey, system_instruction, transaction::Transaction};
+use solana_pubkey::Pubkey;
+use solana_transaction::Transaction;
 use wallet_adapter::Utils;
 
 use crate::{
@@ -34,7 +35,7 @@ pub fn SignTx() -> Element {
                             let pubkey = Pubkey::new_from_array(public_key);
                             let recipient_pubkey = Pubkey::new_from_array(Utils::public_key_rand());
 
-                            let instr = system_instruction::transfer(&pubkey, &recipient_pubkey, lamports);
+                            let instr = solana_system_interface::instruction::transfer(&pubkey, &recipient_pubkey, lamports);
                             let tx = Transaction::new_with_payer(&[instr], Some(&pubkey));
                             let tx_bytes = bincode::serialize(&tx).unwrap();
                             let cluster = CLUSTER_STORAGE.read().active_cluster().cluster();

--- a/wallet-adapter-common/Cargo.toml
+++ b/wallet-adapter-common/Cargo.toml
@@ -20,4 +20,4 @@ rand_chacha.workspace = true
 rand_core.workspace = true
 thiserror.workspace = true
 blake3.workspace = true
-getrandom = { workspace = true, features = ["wasm_js", "sys_rng"] }
+getrandom = { workspace = true, features = ["wasm_js", "std"] }

--- a/wallet-adapter-common/src/signin_standard/signin.rs
+++ b/wallet-adapter-common/src/signin_standard/signin.rs
@@ -132,17 +132,9 @@ impl SigninInput {
     /// This is generated from the Cryptographically Secure Random Number Generator
     /// and the bytes converted to hex formatted string.
     pub fn set_nonce(&mut self) -> &mut Self {
-        use rand_chacha::ChaCha12Rng;
-        use rand_core::{Rng, SeedableRng};
+        let random_bytes = WalletCommonUtils::rand_32bytes();
 
-        let mut rng = ChaCha12Rng::from_seed(Default::default());
-
-        let mut buffer = [0u8; 32];
-
-        rng.fill_bytes(&mut buffer);
-
-        self.nonce.replace(blake3::hash(&buffer).to_string());
-        buffer.fill(0);
+        self.nonce.replace(blake3::hash(&random_bytes).to_string());
 
         self
     }

--- a/wallet-adapter-common/src/utils.rs
+++ b/wallet-adapter-common/src/utils.rs
@@ -21,12 +21,10 @@ impl WalletCommonUtils {
 
     /// Generate a 32 byte array from random bytes
     pub fn rand_32bytes() -> [u8; 32] {
-        use getrandom::SysRng;
-
         use rand_chacha::ChaCha12Rng;
-        use rand_core::{Rng, SeedableRng};
+        use rand_core::{RngCore, SeedableRng};
 
-        let mut rng = ChaCha12Rng::try_from_rng(&mut SysRng).unwrap();
+        let mut rng = ChaCha12Rng::from_os_rng();
         let mut buffer = [0u8; 32];
 
         rng.fill_bytes(&mut buffer);


### PR DESCRIPTION
solana-sdk crashes with newer version of rand causing compile error for wasm target. This commit removes solana-sdk in favour of individual solana-sdk sub-crates to perform the same tasks.

This commit also harmonizes random byte generation and removes duplicate implementation in SIWS.