### PR TITLE
Replace `ed25519-dalek::Signature`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ ed25519-dalek = { version = "2.2.0", default-features = false, features = [
     "signature",
     "fast",
 ] }
+solana-signature = { version = "3.3", features = ["verify"] }
 async-channel = "2.5.0"
 log = "0.4"
 wasm-bindgen-futures = "0.4"

--- a/base/src/sign_in.rs
+++ b/base/src/sign_in.rs
@@ -586,7 +586,7 @@ pub struct SignInOutput<T: WalletAccount + Debug + Clone + Hash + Ord + PartialE
     /// The UTF-8 encoded message
     pub message: String,
     /// The signature as a  byte array of 64 bytes in length corresponding to a
-    /// [Ed25519 Signature](ed25519_dalek::Signature)
+    /// [Ed25519 Signature](solana_signature::Signature)
     pub signature: [u8; 64],
     /// The public key as a  byte array of 32 bytes in length corresponding to a
     /// [Ed25519 Public Key](ed25519_dalek::VerifyingKey)

--- a/crate/Cargo.toml
+++ b/crate/Cargo.toml
@@ -26,6 +26,7 @@ blake3.workspace = true
 async-lock.workspace = true
 wallet-adapter-common.workspace = true
 ed25519-dalek.workspace = true
+solana-signature.workspace = true
 
 [dev-dependencies]
 solana-sdk = "4.0.1"

--- a/crate/src/adapter.rs
+++ b/crate/src/adapter.rs
@@ -2,7 +2,7 @@ use std::{borrow::Borrow, sync::Arc};
 
 use async_channel::{bounded, Receiver};
 use async_lock::RwLock;
-use ed25519_dalek::Signature;
+use solana_signature::Signature;
 use wallet_adapter_common::{clusters::Cluster, signin_standard::SignInOutput};
 use web_sys::{js_sys::Object, Document, Window};
 

--- a/crate/src/utils.rs
+++ b/crate/src/utils.rs
@@ -1,3 +1,4 @@
+use solana_signature::Signature;
 use wallet_adapter_common::WalletCommonUtils;
 use web_sys::{
     js_sys::{self, Array, Function, Object, Reflect},
@@ -21,11 +22,8 @@ impl InnerUtils {
         }
     }
 
-    /// Convert a [JsValue] to a [ed25519_dalek::Signature]
-    pub fn jsvalue_to_signature(
-        value: JsValue,
-        namespace: &str,
-    ) -> WalletResult<ed25519_dalek::Signature> {
+    /// Convert a [JsValue] to a [solana_signature::Signature]
+    pub fn jsvalue_to_signature(value: JsValue, namespace: &str) -> WalletResult<Signature> {
         let in_case_of_error = Err(WalletError::InternalError(format!(
             "{namespace}: `{value:?}` cannot be cast to a Uint8Array, only a JsValue of bytes can be cast."
         )));

--- a/crate/src/wallet_ser_der/standard_features/sign_message.rs
+++ b/crate/src/wallet_ser_der/standard_features/sign_message.rs
@@ -134,7 +134,7 @@ impl SignedMessageOutput<'_> {
 impl Default for SignedMessageOutput<'_> {
     fn default() -> Self {
         Self {
-            message: &[],
+            message: [].as_slice(),
             public_key: [0u8; 32],
             signature: [0u8; 64],
         }

--- a/crate/src/wallet_ser_der/standard_features/sign_message.rs
+++ b/crate/src/wallet_ser_der/standard_features/sign_message.rs
@@ -1,4 +1,5 @@
-use ed25519_dalek::{Signature, VerifyingKey};
+use ed25519_dalek::VerifyingKey;
+use solana_signature::Signature;
 use wallet_adapter_common::WalletCommonUtils;
 use web_sys::{js_sys, wasm_bindgen::JsValue};
 
@@ -84,7 +85,7 @@ impl SignMessage {
             Ok(SignedMessageOutput {
                 message,
                 public_key: wallet_account.account.public_key,
-                signature: signature.to_bytes(),
+                signature: signature.into(),
             })
         } else {
             Err(WalletError::ReceivedAnEmptySignedMessagesArray)

--- a/crate/src/wallet_ser_der/standard_features/sign_tx.rs
+++ b/crate/src/wallet_ser_der/standard_features/sign_tx.rs
@@ -1,4 +1,4 @@
-use ed25519_dalek::Signature;
+use solana_signature::Signature;
 use wallet_adapter_common::{clusters::Cluster, WalletCommonUtils};
 use web_sys::{
     js_sys::{self, Function},

--- a/crate/src/wallet_ser_der/standard_features/sign_tx.rs
+++ b/crate/src/wallet_ser_der/standard_features/sign_tx.rs
@@ -7,10 +7,12 @@ use web_sys::{
 
 use core::hash::Hash;
 
-use crate::{Commitment, Reflection, SemverVersion, WalletAccount, WalletError, WalletResult};
+use crate::{
+    noop, Commitment, Reflection, SemverVersion, WalletAccount, WalletError, WalletResult,
+};
 
 /// Used in `solana:SignTransaction` and `solana:SignAndSendTransaction`.
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignTransaction {
     /// The [semver version](SemverVersion) of the
     /// callback function supported by the wallet
@@ -23,6 +25,17 @@ pub struct SignTransaction {
     // Internally called. Can be either `solana:signTransaction`
     // or `solana:signAndSendTransaction` callback function
     callback: Function,
+}
+
+impl Default for SignTransaction {
+    fn default() -> Self {
+        Self {
+            version: SemverVersion::default(),
+            legacy: false,
+            version_zero: false,
+            callback: noop(),
+        }
+    }
 }
 
 impl SignTransaction {

--- a/crate/src/wallet_ser_der/standard_features/standard_fn.rs
+++ b/crate/src/wallet_ser_der/standard_features/standard_fn.rs
@@ -1,16 +1,32 @@
 use core::hash::Hash;
 
 use web_sys::js_sys::Function;
+use web_sys::wasm_bindgen::{closure::Closure, JsCast, JsValue};
 
 use crate::{Reflection, SemverVersion, WalletError, WalletResult};
 
 /// A struct containing the [semver version](SemverVersion)
 /// and [callback function](Function) within the `standard:` namespace as
 /// defined by the wallet standard
-#[derive(Debug, Clone, Default, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StandardFunction {
     pub(crate) version: SemverVersion,
     pub(crate) callback: Function,
+}
+
+impl Default for StandardFunction {
+    fn default() -> Self {
+        Self {
+            version: SemverVersion::default(),
+            callback: noop(),
+        }
+    }
+}
+
+pub(crate) fn noop() -> Function {
+    Closure::<dyn FnMut() -> JsValue>::new(|| JsValue::UNDEFINED)
+        .into_js_value()
+        .unchecked_into()
 }
 
 impl StandardFunction {

--- a/crate/src/wallet_ser_der/wallet.rs
+++ b/crate/src/wallet_ser_der/wallet.rs
@@ -1,7 +1,7 @@
 use std::borrow::Cow;
 
 use async_channel::Receiver;
-use ed25519_dalek::Signature;
+use solana_signature::Signature;
 use wallet_adapter_common::{
     chains::ChainSupport, clusters::Cluster, signin_standard::SignInOutput, WalletData,
 };

--- a/wallet-adapter-common/Cargo.toml
+++ b/wallet-adapter-common/Cargo.toml
@@ -15,6 +15,7 @@ rust-version.workspace = true
 [dependencies]
 bs58.workspace = true
 ed25519-dalek.workspace = true
+solana-signature.workspace = true
 humantime.workspace = true
 rand_chacha.workspace = true
 rand_core.workspace = true

--- a/wallet-adapter-common/src/signin_standard/output.rs
+++ b/wallet-adapter-common/src/signin_standard/output.rs
@@ -8,7 +8,7 @@ pub struct SignInOutput {
     /// The UTF-8 encoded message
     pub message: String,
     /// The signature as a  byte array of 64 bytes in length corresponding to a
-    /// [Ed25519 Signature](ed25519_dalek::Signature)
+    /// [Ed25519 Signature](solana_signature::Signature)
     pub signature: [u8; 64],
     /// The public key as a  byte array of 32 bytes in length corresponding to a
     /// [Ed25519 Public Key](ed25519_dalek::VerifyingKey)

--- a/wallet-adapter-common/src/utils.rs
+++ b/wallet-adapter-common/src/utils.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, time::SystemTime};
 
-use ed25519_dalek::{Signature, Verifier, VerifyingKey};
+use ed25519_dalek::VerifyingKey;
+use solana_signature::Signature;
 
 use crate::{WalletUtilsError, WalletUtilsResult};
 
@@ -40,7 +41,7 @@ impl WalletCommonUtils {
 
     /// Parse a [Signature] from an array of 64 bytes
     pub fn signature(signature_bytes: &[u8; 64]) -> Signature {
-        Signature::from_bytes(signature_bytes)
+        Signature::from(*signature_bytes)
     }
 
     /// Convert a slice of bytes into a 32 byte array. This is useful especially if a [PublicKey](VerifyingKey) is
@@ -65,9 +66,10 @@ impl WalletCommonUtils {
         message: &[u8],
         signature: Signature,
     ) -> WalletUtilsResult<()> {
-        public_key
-            .verify(message, &signature)
-            .or(Err(WalletUtilsError::InvalidSignature))
+        signature
+            .verify(public_key.as_bytes(), message)
+            .then_some(()) // todo: rm once stable https://github.com/rust-lang/rust/issues/142748
+            .ok_or(WalletUtilsError::InvalidSignature)
     }
 
     /// Verify a [message](str) using a [PublicKey](VerifyingKey) and [Signature]
@@ -79,9 +81,10 @@ impl WalletCommonUtils {
         let public_key = Self::public_key(public_key_bytes)?;
         let signature = Self::signature(signature_bytes);
 
-        public_key
-            .verify(message_bytes, &signature)
-            .or(Err(WalletUtilsError::InvalidSignature))
+        signature
+            .verify(public_key.as_bytes(), message_bytes)
+            .then_some(()) // todo: rm once stable https://github.com/rust-lang/rust/issues/142748
+            .ok_or(WalletUtilsError::InvalidSignature)
     }
 
     /// Generate the Base58 address from a [PublicKey](VerifyingKey)
@@ -91,7 +94,7 @@ impl WalletCommonUtils {
 
     /// Generate a Base58 encoded string from a [Signature]
     pub fn base58_signature(signature: Signature) -> String {
-        bs58::encode(signature.to_bytes()).into_string()
+        bs58::encode(signature.as_array()).into_string()
     }
 
     /// Get the shortened string of the `Base58 string` .


### PR DESCRIPTION
Closes https://github.com/JamiiDao/SolanaWalletAdapter/issues/142

- Replaces use of `ed25519-dalek::Signature` with `solana_singature::Signature`
- Fixes compilation bug on rustc 1.93.0, caused by derive `Default` for nested type `web_sys::js_sys::Function`